### PR TITLE
Fix plugin loader

### DIFF
--- a/src/main/java/emulib/runtime/PluginLoader.java
+++ b/src/main/java/emulib/runtime/PluginLoader.java
@@ -302,12 +302,7 @@ public class PluginLoader extends ClassLoader {
                     }
                 }
             }
-            Class<?> newClass = theClass.getSuperclass();
-            if (newClass == null) {
-                theClass = theClass.getEnclosingClass();
-            } else {
-                theClass = newClass;
-            }
+            theClass = theClass.getSuperclass();
         } while ((theClass != null) && !theClass.equals(Object.class));
 
         return false;


### PR DESCRIPTION
The plugin loader should not check for enclosing classes when finding the main plugin class. If an enclosing class implenents `IPlugin`, it does not mean that the inner/nested class also implements it.

For example:
The anonymous inner class `EdigenStatusPanel$1` implements `ICPUListener`, which is a nested interface of `ICPU`. But `EdigenStatusPanel$1` is definitely neither a main CPU plugin class, nor does it implement the `ICPU` interface.

The mentioned behavior also causes an Edigen CPU loading failure.
