### PR TITLE
Fix helpers/IO bugs (#111) and add C4 architecture docs (#112)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ gradle-app.setting
 .ammonite/
 .metals-sbt/
 .scala-build/
+
+# Generated AsciiDoc documentation (./gradlew doc)
+docs/output/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# emuStudio Repo Routing
+
+## Repository Map
+- `/home/vbmacher/projects/emustudio/emuLib`: shared runtime library for emuStudio. Owns plugin API contracts, runtime services, settings/context APIs, Swing helpers, and reusable utilities.
+- `/home/vbmacher/projects/emustudio/edigen`: generator for instruction decoders and disassemblers from `.eds` specifications. Owns the DSL, parser, and generated decoder/disassembler code shape.
+- `/home/vbmacher/projects/emustudio/emuStudio`: desktop application, CLI launcher, bundled official plugins, bundled virtual computers, configs, and distribution packaging.
+- `/home/vbmacher/projects/emustudio/emustudio.github.io`: website, user documentation, developer documentation, release-facing pages, and download-related content.
+- `/home/vbmacher/projects/emustudio/edigen-gradle-plugin`: Gradle integration for Edigen. Owns Gradle tasks and DSL for source generation from `.eds`.
+- `/home/vbmacher/projects/emustudio/cpu-testsuite`: shared CPU instruction test framework. Owns reusable CPU test builders, fixtures, and verification helpers.
+
+## Task Routing
+- Shared plugin API, common utility, runtime service, or reusable UI helper change: update `emuLib`; also check `emuStudio`, `edigen`, and `cpu-testsuite` for consumers.
+- Desktop app behavior, plugin wiring, bundled configs, bundled computers, or packaging change: update `emuStudio`; check `emuLib` if the task needs shared API support.
+- `.eds` syntax, decoder generation, disassembler generation, or generated code semantics change: update `edigen`; also check `edigen-gradle-plugin` and any affected bundled CPUs in `emuStudio`.
+- Gradle build integration for generated decoders/disassemblers: update `edigen-gradle-plugin`; check `edigen` if the task depends on generator inputs or outputs.
+- Shared CPU testing API or reusable instruction-test helper change: update `cpu-testsuite`; check `emuStudio` CPU plugin tests that consume it.
+- User-facing docs, developer guides, website pages, release notes, or download links: update `emustudio.github.io`; also update the owning code repository when behavior changed.
+- Cross-repository emulator feature work: start with the owning repository above, then update every listed consumer repository that depends on that contract or behavior.
+
+## Tickets And Commits
+- Every change must be tied to an existing GitHub ticket before edits are finalized.
+- Every commit message must start with the ticket prefix in this format: `[#123] Short summary`.
+- If one task spans multiple repositories, use the same ticket number in each related commit.

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ import com.vanniktech.maven.publish.DeploymentValidation
 plugins {
   id 'java-library'
   id "com.vanniktech.maven.publish" version "0.36.0"
+  id "org.asciidoctor.jvm.convert" version "4.0.4"
 }
 
 java {
@@ -107,4 +108,34 @@ javadoc {
   if (JavaVersion.current().isJava9Compatible()) {
     options.addBooleanOption('html5', true)
   }
+}
+
+asciidoctorj {
+  modules {
+    diagram.use()
+  }
+}
+
+tasks.register('doc', org.asciidoctor.gradle.jvm.AsciidoctorTask) {
+  group = 'documentation'
+  description = 'Renders the AsciiDoc documents in docs/ to HTML into docs/output/'
+
+  sourceDir file('docs')
+  sources {
+    include '*.adoc'
+  }
+  outputDir file('docs/output')
+  baseDirFollowsSourceFile()
+
+  outputOptions {
+    backends = ['html5']
+    separateOutputDirs = false
+  }
+
+  attributes 'source-highlighter': 'rouge',
+             'toc'               : 'left',
+             'icons'             : 'font',
+             'sectanchors'       : '',
+             'idprefix'          : '',
+             'idseparator'       : '-'
 }

--- a/docs/architecture.adoc
+++ b/docs/architecture.adoc
@@ -1,0 +1,479 @@
+= emuLib Architecture (C4 Model)
+:toc: left
+:toclevels: 3
+:sectnums:
+:sectnumlevels: 3
+:icons: font
+:source-highlighter: rouge
+:experimental:
+
+This document describes the software architecture of *emuLib* using the
+https://c4model.com/[C4 model] (Context, Containers, Components, Code).
+
+emuLib is the shared runtime library used by
+https://github.com/emustudio/emuStudio[emuStudio] and its plugins. It defines the
+public plugin API (contracts and abstract base classes for CPU, memory, compiler
+and device plugins), runtime services for application integration and inter-plugin
+communication, settings interfaces, Swing UI helpers, and reusable utilities.
+
+[NOTE]
+====
+The diagrams below are written with
+https://github.com/plantuml-stdlib/C4-PlantUML[C4-PlantUML] (bundled in the
+PlantUML standard library). To render this document to HTML/PDF with the diagrams
+inlined, use https://asciidoctor.org/[Asciidoctor] together with
+https://github.com/asciidoctor/asciidoctor-diagram[asciidoctor-diagram] and a
+local PlantUML/Graphviz installation:
+
+[source,bash]
+----
+asciidoctor -r asciidoctor-diagram docs/architecture.adoc
+----
+
+If you do not have `asciidoctor-diagram`, the fenced diagram sources can still be
+copied into any PlantUML renderer.
+====
+
+== Overview
+
+emuLib is not a runnable application; it is a *Java library* (a single `emulib.jar`)
+that is loaded into the JVM of the emuStudio desktop application at runtime and
+compiled against by every plugin. Its architecture therefore centres on three
+responsibilities:
+
+* *Plugin contracts* — interfaces and abstract base classes that every plugin
+  (CPU, Memory, Compiler, Device) implements, so the host can load and control them
+  uniformly.
+* *Runtime services* — the `ApplicationApi` the host exposes to plugins, and the
+  `ContextPool` through which plugins discover and talk to each other via typed
+  _contexts_.
+* *Reusable building blocks* — number/radix/bit utilities, Intel HEX I/O, settings
+  abstractions, and Swing helpers (dialogs, debugger table).
+
+.C4 abstraction mapping for emuLib
+[cols="1,2,3",options="header"]
+|===
+| C4 level | In this document | Notes
+
+| Context (L1)   | emuLib within the emuStudio ecosystem | People and systems that use the library
+| Container (L2) | The `emulib.jar` artifact in the emuStudio JVM | A library has a single deployable container; consumers and 3rd-party deps shown around it
+| Component (L3) | Java packages inside `emulib.jar` | Plugin API, Runtime, Settings, Helpers, I/O, UI, Memory annotations
+| Code (L4)      | Key interfaces & class hierarchies | Plugin hierarchy, Context/ContextPool, CPU execution model
+|===
+
+== Level 1 — System Context
+
+At the highest level emuLib sits between the *emuStudio host application* and the
+*plugins* that extend it. Plugin developers write plugins against the emuLib API;
+emuStudio provides the concrete runtime implementations (context pool, settings,
+dialogs, GUI, debugger table) that emuLib only declares as interfaces.
+
+[plantuml,c4-l1-context,svg]
+....
+@startuml
+!include <C4/C4_Context>
+
+title System Context — emuLib
+
+Person(dev, "Plugin Developer", "Builds emuStudio plugins (CPU, memory, compiler, device) against the emuLib API")
+
+System(emulib, "emuLib", "Shared runtime library (emulib.jar): plugin contracts, runtime services, utilities and Swing UI helpers")
+
+System_Ext(emustudio, "emuStudio Application", "Desktop emulation platform. Loads plugins and provides concrete implementations of the runtime services declared by emuLib")
+System_Ext(plugins, "emuStudio Plugins", "CPU / Memory / Compiler / Device plugins that implement emuLib interfaces and communicate through contexts")
+System_Ext(maven, "Maven Central", "Distributes the published net.emustudio:emulib artifact")
+
+Rel(dev, emulib, "Compiles against the API, uses utilities")
+Rel(dev, plugins, "Develops")
+
+Rel(plugins, emulib, "Implement Plugin / Context interfaces; use helpers, settings, UI helpers")
+Rel(emustudio, emulib, "Implements ApplicationApi, ContextPool, PluginSettings, Dialogs, GUI, DebuggerTable; drives plugin lifecycle")
+Rel(emustudio, plugins, "Instantiates, configures and controls (reset/step/run/stop)")
+
+Rel(plugins, plugins, "Communicate via typed contexts obtained from the ContextPool")
+Rel(emulib, maven, "Published to", "Gradle / maven-publish")
+
+@enduml
+....
+
+=== Key relationships
+
+* *Plugin Developer → emuLib.* Developers compile their plugin root class against a
+  plugin interface (`CPU`, `Memory`, `Compiler`, `Device`) or extend an
+  `Abstract*` base class, and reuse helpers such as `NumberUtils`, `RadixUtils`,
+  `IntelHEX`, and the debugger UI components.
+* *emuStudio → emuLib.* emuLib declares the host services as _interfaces_
+  (`ApplicationApi`, `ContextPool`, `PluginSettings`, `Dialogs`, `GUI`,
+  `DebuggerTable`). emuStudio provides the concrete implementations and injects them
+  into every plugin through the plugin constructor.
+* *Plugins ↔ Plugins.* Direct plugin-to-plugin coupling is avoided. Instead a plugin
+  _registers_ a `Context` and other plugins _obtain_ it from the `ContextPool`,
+  keyed by a `@PluginContext`-annotated interface.
+
+== Level 2 — Container
+
+emuLib ships as one artifact, `emulib.jar` (Maven coordinates
+`net.emustudio:emulib`, Java 11 bytecode). At runtime it lives inside the emuStudio
+JVM next to the host application and the loaded plugin JARs. Its only third-party
+couplings are lightweight, `compileOnly` dependencies.
+
+[plantuml,c4-l2-container,svg]
+....
+@startuml
+!include <C4/C4_Container>
+
+title Container — emuLib inside the emuStudio runtime (JVM)
+
+Person(dev, "Plugin Developer", "Builds plugins")
+
+System_Boundary(rt, "emuStudio Runtime (JVM)") {
+  Container(emustudioApp, "emuStudio Application", "Java desktop app (Swing)", "Host platform; implements the runtime service interfaces declared by emuLib")
+  Container(emulib, "emuLib", "Java library — emulib.jar", "Plugin API + runtime services + utilities + UI helpers")
+  Container(pluginJars, "Plugin JARs", "Java libraries", "CPU / Memory / Compiler / Device implementations")
+}
+
+System_Ext(maven, "Maven Central", "Artifact distribution")
+Container_Ext(slf4j, "SLF4J API", "Java library (compileOnly)", "Logging facade used by abstract base classes")
+Container_Ext(jcip, "jcip-annotations", "Java library (compileOnly)", "@ThreadSafe / @GuardedBy documentation annotations")
+
+Rel(dev, maven, "Resolves dependency from")
+Rel(maven, emulib, "Provides")
+
+Rel(pluginJars, emulib, "Compile & run against")
+Rel(emustudioApp, emulib, "Implements service interfaces; drives plugin lifecycle")
+Rel(emustudioApp, pluginJars, "Loads & controls")
+Rel(pluginJars, emustudioApp, "Call back via ApplicationApi (implemented by host)")
+
+Rel(emulib, slf4j, "Logs through", "compileOnly")
+Rel(emulib, jcip, "Annotated with", "compileOnly")
+
+@enduml
+....
+
+=== Container notes
+
+* *Single deployable.* There is exactly one container to deploy — `emulib.jar`.
+  When bundled manually it is placed under `emuStudio/lib/emulib.jar`.
+* *`compileOnly` dependencies.* `slf4j-api` and `jcip-annotations` are compile-time
+  only (see `build.gradle`). SLF4J is used by the abstract base classes for logging;
+  the host application supplies an SLF4J binding at runtime. jcip annotations
+  (`@ThreadSafe`) are purely documentary.
+* *No transitive runtime dependencies.* emuLib deliberately keeps its runtime
+  footprint minimal so it does not impose libraries on plugins or the host.
+* *Java compatibility.* Compiled to Java 11 bytecode; the Gradle 9 wrapper itself
+  requires JDK 17+ to build.
+
+== Level 3 — Component
+
+Inside `emulib.jar`, functionality is organised into cohesive Java packages. The
+component diagram groups them by responsibility and shows the main dependencies.
+
+[plantuml,c4-l3-component,svg]
+....
+@startuml
+!include <C4/C4_Component>
+
+title Component — packages inside emulib.jar
+
+Container_Boundary(emulib, "emuLib (emulib.jar)") {
+
+  Component(pluginApi, "Plugin API", "net.emustudio.emulib.plugins(.cpu/.memory/.compiler/.device)", "Plugin & Context contracts, plugin-type interfaces, abstract base classes")
+  Component(annotations, "Plugin Annotations", "net.emustudio.emulib.plugins.annotations", "@PluginRoot, @PluginContext, PLUGIN_TYPE — plugin discovery metadata")
+  Component(memAnno, "Memory Annotations", "net.emustudio.emulib.plugins.memory.annotations", "Per-cell annotations: breakpoints, source-code positions, text/data markers")
+
+  Component(runtime, "Runtime Services", "net.emustudio.emulib.runtime", "ApplicationApi (host facade) + ContextPool (context registry) + context exceptions")
+  Component(settings, "Settings", "net.emustudio.emulib.runtime.settings", "BasicSettings / PluginSettings — typed read/write of plugin configuration")
+
+  Component(helpers, "Helpers / Utilities", "net.emustudio.emulib.runtime.helpers", "Bits, NumberUtils, RadixUtils, StringUtils, SleepUtils, ReadWriteLockSupport, Unchecked")
+  Component(io, "I/O", "net.emustudio.emulib.runtime.io", "IntelHEX — Intel HEX import/export")
+
+  Component(ui, "UI Helpers", "net.emustudio.emulib.runtime.ui", "Dialogs, GUI factory, Constants, ShortenedString")
+  Component(uiComp, "UI Components", "net.emustudio.emulib.runtime.ui.components", "Reusable Swing widgets (dialogs base, combo model, file filters)")
+  Component(debugger, "Debugger UI", "net.emustudio.emulib.runtime.ui.debugger", "DebuggerTable + columns (address, mnemo, opcode, breakpoint)")
+}
+
+System_Ext(emustudio, "emuStudio Application", "Implements the service interfaces")
+System_Ext(plugin, "A Plugin", "Implements Plugin API")
+
+' Plugin API wiring
+Rel(pluginApi, annotations, "Marked with")
+Rel(pluginApi, runtime, "Receives ApplicationApi; uses ContextPool")
+Rel(pluginApi, settings, "Reads/writes via PluginSettings")
+Rel(pluginApi, helpers, "Uses")
+Rel(pluginApi, memAnno, "Memory exposes")
+
+' Runtime wiring
+Rel(runtime, pluginApi, "Registers/looks up Context objects")
+Rel(runtime, ui, "ApplicationApi exposes Dialogs / GUI")
+Rel(runtime, debugger, "ApplicationApi exposes DebuggerTable")
+
+Rel(io, helpers, "Uses number/radix utilities")
+Rel(debugger, uiComp, "Built from")
+Rel(ui, uiComp, "Uses")
+
+' External
+Rel(plugin, pluginApi, "Implements")
+Rel(plugin, helpers, "Uses")
+Rel(plugin, io, "Uses (compilers load code)")
+Rel(emustudio, runtime, "Implements ApplicationApi & ContextPool")
+Rel(emustudio, settings, "Implements PluginSettings")
+Rel(emustudio, ui, "Implements Dialogs & GUI")
+Rel(emustudio, debugger, "Implements DebuggerTable")
+
+@enduml
+....
+
+=== Component responsibilities
+
+[cols="1,2,3",options="header"]
+|===
+| Component | Package(s) | Responsibility
+
+| Plugin API
+| `plugins`, `plugins.cpu`, `plugins.memory`, `plugins.compiler`, `plugins.device`
+| Core contracts: `Plugin` and its derivatives `CPU`, `Memory`, `Compiler`,
+  `Device`; the `Context` marker and the per-type contexts; and `Abstract*` base
+  classes (`AbstractCPU`, `AbstractMemory`, `AbstractDevice`, `AbstractCompiler`,
+  `AbstractMemoryContext`, `AbstractCPUContext`) that implement common behaviour.
+
+| Plugin Annotations
+| `plugins.annotations`
+| `@PluginRoot(title, type)` marks a plugin's root class; `@PluginContext` marks
+  context interfaces; `PLUGIN_TYPE` enumerates `COMPILER/CPU/MEMORY/DEVICE`.
+
+| Memory Annotations
+| `plugins.memory.annotations`
+| Rich per-cell metadata API (`MemoryContextAnnotations`, `Annotation`,
+  `BreakpointAnnotation`, `SourceCodeAnnotation`, …) attached to memory cells.
+
+| Runtime Services
+| `runtime`
+| `ApplicationApi` — the host facade handed to every plugin; `ContextPool` — the
+  registry that lets plugins publish and discover contexts; context exceptions
+  (`ContextNotFoundException`, `ContextAlreadyRegisteredException`,
+  `InvalidContextException`).
+
+| Settings
+| `runtime.settings`
+| `BasicSettings` / `PluginSettings` — typed (`String/boolean/int/long/double/array`)
+  configuration access, sub-settings, and reserved `emustudio.` keys.
+
+| Helpers / Utilities
+| `runtime.helpers`
+| Bit/number/radix/string utilities (`Bits`, `NumberUtils`, `RadixUtils`,
+  `StringUtils`), timing (`SleepUtils`), concurrency (`ReadWriteLockSupport`) and
+  functional glue (`Unchecked`).
+
+| I/O
+| `runtime.io`
+| `IntelHEX` — reading and writing Intel HEX files (used by compilers to emit code
+  and by the runtime to load it into memory).
+
+| UI Helpers
+| `runtime.ui`, `runtime.ui.components`
+| `Dialogs` (message/confirm/input, headless-aware), `GUI` factory, reusable Swing
+  widgets, file-extension filters, and text helpers.
+
+| Debugger UI
+| `runtime.ui.debugger`
+| `DebuggerTable` abstraction and its pluggable `DebuggerColumn` implementations
+  (address, mnemonic, opcode, breakpoint) that CPUs feed via their `Disassembler`.
+|===
+
+== Level 4 — Code
+
+The following class diagrams zoom into the most important contracts.
+
+=== Plugin type hierarchy
+
+Every plugin's root class implements `Plugin` (usually through one of the four
+specialised interfaces) and is annotated with `@PluginRoot`. emuLib provides
+`Abstract*` base classes that implement the boilerplate.
+
+[plantuml,c4-l4-plugin,svg]
+....
+@startuml
+title Code — Plugin hierarchy
+
+interface Plugin {
+  +initialize()
+  +reset()
+  +destroy()
+  +showSettings(JFrame)
+  +getTitle() : String
+  +getVersion() : String
+  +isAutomationSupported() : boolean
+}
+
+interface CPU
+interface Memory
+interface Compiler
+interface Device
+
+Plugin <|-- CPU
+Plugin <|-- Memory
+Plugin <|-- Compiler
+Plugin <|-- Device
+
+abstract class AbstractCPU
+abstract class AbstractMemory
+abstract class AbstractDevice
+abstract class AbstractCompiler
+
+CPU <|.. AbstractCPU
+Memory <|.. AbstractMemory
+Device <|.. AbstractDevice
+Compiler <|.. AbstractCompiler
+
+annotation PluginRoot {
+  +title : String
+  +type : PLUGIN_TYPE
+}
+enum PLUGIN_TYPE {
+  COMPILER
+  CPU
+  MEMORY
+  DEVICE
+}
+PluginRoot ..> PLUGIN_TYPE
+
+note bottom of AbstractCPU
+  Constructor contract for every root class:
+  (long pluginId, ApplicationApi api, PluginSettings settings)
+end note
+@enduml
+....
+
+* A plugin is a *single* root class implementing `Plugin` (or a derivative) and
+  annotated `@PluginRoot`.
+* The mandated constructor `(long pluginId, ApplicationApi, PluginSettings)` is how
+  the host injects the runtime services and the plugin's persisted configuration.
+* Lifecycle: `initialize()` (contexts may be obtained here) → `reset()` / run →
+  `destroy()` (unregister contexts, release resources).
+
+=== Contexts and the ContextPool
+
+Contexts are the inter-plugin communication mechanism. A plugin registers context
+objects during construction; consumers look them up (reliably) during
+`initialize()`.
+
+[plantuml,c4-l4-context,svg]
+....
+@startuml
+title Code — Context registry & inter-plugin communication
+
+interface ApplicationApi {
+  +getContextPool() : ContextPool
+  +getDialogs() : Dialogs
+  +getGUI() : GUI
+  +getDebuggerTable() : DebuggerTable
+  +get/setProgramLocation()
+}
+
+interface ContextPool {
+  +register(pluginID, Context, Class)
+  +unregister(pluginID, Class) : boolean
+  +getContext(pluginID, Class, index) : T
+  +getCPUContext(...)
+  +getMemoryContext(...)
+  +getDeviceContext(...)
+  +getCompilerContext(...)
+}
+
+interface Context <<@PluginContext>>
+interface CPUContext
+interface "MemoryContext<CellType>" as MemoryContext
+interface "DeviceContext<DataType>" as DeviceContext
+interface CompilerContext
+
+Context <|-- CPUContext
+Context <|-- MemoryContext
+Context <|-- DeviceContext
+Context <|-- CompilerContext
+
+ApplicationApi --> ContextPool : exposes
+ContextPool o--> "*" Context : registers / resolves
+
+note right of ContextPool
+  Keyed by the @PluginContext interface.
+  Multiple contexts per interface are
+  addressed by a 0-based index.
+end note
+@enduml
+....
+
+=== Runtime scenario — plugin wiring & communication
+
+The dynamic view below shows the typical startup and cross-plugin interaction:
+the host constructs plugins (they register contexts), initialises them (they resolve
+contexts), and then plugins talk to each other purely through those contexts.
+
+[plantuml,c4-l4-dynamic,svg]
+....
+@startuml
+title Dynamic — startup wiring and inter-plugin communication
+
+actor emuStudio
+participant "CPU plugin" as CPU
+participant "Memory plugin" as MEM
+participant "Device plugin" as DEV
+participant "ContextPool" as POOL
+
+== Construction (register contexts) ==
+emuStudio -> MEM : new(pluginId, api, settings)
+MEM -> POOL : register(MemoryContext)
+emuStudio -> DEV : new(pluginId, api, settings)
+DEV -> POOL : register(DeviceContext)
+emuStudio -> CPU : new(pluginId, api, settings)
+CPU -> POOL : register(CPUContext)
+
+== Initialization (resolve contexts) ==
+emuStudio -> CPU : initialize()
+CPU -> POOL : getMemoryContext(pluginId, ...)
+POOL --> CPU : MemoryContext
+CPU -> POOL : getDeviceContext(pluginId, ...)
+POOL --> CPU : DeviceContext
+
+== Emulation ==
+emuStudio -> CPU : execute()
+CPU -> MEM : read(address)
+MEM --> CPU : cell
+CPU -> DEV : writeData(value)   // "OUT"
+DEV --> CPU : (ack)
+CPU -> CPU : signalInterrupt()?  // via CPUContext
+@enduml
+....
+
+== Cross-cutting concerns
+
+Concurrency::
+Contexts must be thread-safe (`Context` is `@ThreadSafe`) because there is no
+guarantee about which thread performs plugin communication. `AbstractCPU` runs the
+fetch/decode/execute loop on its own single-thread executor and manages `RunState`
+transitions and listeners in a thread-safe way. `ReadWriteLockSupport` helps plugins
+guard shared state.
+
+Headless / automation mode::
+The API is usable without a GUI. `ApplicationApi.UNAVAILABLE` and
+`PluginSettings.UNAVAILABLE` provide no-op implementations for embedding a plugin
+without emuStudio (e.g. a command-line tool), and `Dialogs` degrades to logging when
+GUI is disabled. Plugins advertise `isAutomationSupported()`.
+
+Extensibility::
+New capabilities are added by *extending context interfaces* (each annotated
+`@PluginContext`) rather than by changing core contracts, keeping the plugin ABI
+stable. Memory cell type and device data type are generic
+(`MemoryContext<CellType>`, `DeviceContext<DataType>`).
+
+Distribution & versioning::
+Published to Maven Central as `net.emustudio:emulib`. Group/artifact coordinates
+changed at 9.0.0 (`net.sf.emustudio:emuLib` → `net.emustudio:emulib` from 10.0.0).
+
+== References
+
+* Source packages: `src/main/java/net/emustudio/emulib/...`
+* Build: `build.gradle`, `settings.gradle`
+* Project README: `README.md`
+* emuStudio developer guide: https://www.emustudio.net/documentation/developer/introduction/
+* C4 model: https://c4model.com/
+* C4-PlantUML: https://github.com/plantuml-stdlib/C4-PlantUML

--- a/src/main/java/net/emustudio/emulib/plugins/compiler/FileExtension.java
+++ b/src/main/java/net/emustudio/emulib/plugins/compiler/FileExtension.java
@@ -78,9 +78,9 @@ public class FileExtension {
      */
     public static String stripKnownExtension(String fileName, Iterable<FileExtension> knownExtensions) {
         for (FileExtension extension : knownExtensions) {
-            int i = fileName.lastIndexOf("." + extension.getExtension());
-            if (i >= 0) {
-                return fileName.substring(0, i);
+            String suffix = "." + extension.getExtension();
+            if (fileName.endsWith(suffix)) {
+                return fileName.substring(0, fileName.length() - suffix.length());
             }
         }
         return fileName;

--- a/src/main/java/net/emustudio/emulib/plugins/compiler/SourceCodePosition.java
+++ b/src/main/java/net/emustudio/emulib/plugins/compiler/SourceCodePosition.java
@@ -45,6 +45,15 @@ public class SourceCodePosition {
     }
 
     /**
+     * Gets file name
+     *
+     * @return file name (non-null)
+     */
+    public String getFileName() {
+        return fileName;
+    }
+
+    /**
      * Creates new SourceCodePosition object
      *
      * @param line     line

--- a/src/main/java/net/emustudio/emulib/runtime/helpers/NumberUtils.java
+++ b/src/main/java/net/emustudio/emulib/runtime/helpers/NumberUtils.java
@@ -71,10 +71,14 @@ public class NumberUtils {
 
     /**
      * Reverse bits in long (max 64-bit) value.
+     * <p>
+     * Note: this overload behaves differently from {@link #reverseBits(int, int)} by design. Only the lowest
+     * {@code numberOfBits} bits are kept and reversed; any higher bits of {@code value} are discarded (not
+     * preserved), and {@code numberOfBits <= 0} yields {@code 0}.
      *
      * @param value        value which bits will be reversed
      * @param numberOfBits how many bits should be reversed. If the value has more bits, the rest will be ignored.
-     * @return value with reversed bits
+     * @return value with the lowest {@code numberOfBits} bits reversed and higher bits cleared
      */
     public static long reverseBits(long value, int numberOfBits) {
         if (numberOfBits <= 0) {
@@ -667,10 +671,6 @@ public class NumberUtils {
             }
         }
         return value;
-    }
-
-    private static int reverseByte(int value) {
-        return REVERSED_BYTES[value & 0xFF] & 0xFF;
     }
 
     private static byte[] createReversedBytes() {

--- a/src/main/java/net/emustudio/emulib/runtime/helpers/RadixUtils.java
+++ b/src/main/java/net/emustudio/emulib/runtime/helpers/RadixUtils.java
@@ -124,8 +124,7 @@ public class RadixUtils {
         patterns.add(new NumberPattern("[0-9a-f]+h", 16, 0, 1));
         patterns.add(new NumberPattern("[0-9]+", 10, 0, 0));
         patterns.add(new NumberPattern("[0-9]+d", 10, 0, 1));
-        patterns.add(new NumberPattern("0[0-9]+", 8, 1, 0));
-        patterns.add(new NumberPattern("[0-9]+o", 8, 0, 1));
+        patterns.add(new NumberPattern("[0-7]+o", 8, 0, 1));
     }
 
     /**

--- a/src/main/java/net/emustudio/emulib/runtime/helpers/SleepUtils.java
+++ b/src/main/java/net/emustudio/emulib/runtime/helpers/SleepUtils.java
@@ -2,10 +2,14 @@
    SPDX-License-Identifier: GPL-3.0-or-later */
 package net.emustudio.emulib.runtime.helpers;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Sleeping and time measurement utilities.
  */
 public class SleepUtils {
+    private final static Logger LOGGER = LoggerFactory.getLogger(SleepUtils.class);
 
     /**
      * Constructs a new SleepUtils instance.
@@ -38,8 +42,8 @@ public class SleepUtils {
         SLEEP_PRECISION = time / count;
         SPIN_YIELD_PRECISION = SLEEP_PRECISION / 2;
 
-        System.out.println("Sleep precision: " + SLEEP_PRECISION + " ns");
-        System.out.println("Spin yield precision: " + SPIN_YIELD_PRECISION + " ns");
+        LOGGER.debug("Sleep precision: {} ns", SLEEP_PRECISION);
+        LOGGER.debug("Spin yield precision: {} ns", SPIN_YIELD_PRECISION);
     }
 
 

--- a/src/main/java/net/emustudio/emulib/runtime/helpers/StringUtils.java
+++ b/src/main/java/net/emustudio/emulib/runtime/helpers/StringUtils.java
@@ -5,6 +5,7 @@ package net.emustudio.emulib.runtime.helpers;
 import java.awt.*;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Locale;
 
 /**
  * String utility class.
@@ -51,12 +52,19 @@ public class StringUtils {
     public static String shorten(String string, Component component, int componentWidth) {
         FontMetrics fontMetrics = component.getFontMetrics(component.getFont());
         int baseNameWidth = fontMetrics.stringWidth(string);
+        if (baseNameWidth <= 0) {
+            return string;
+        }
         int maxPathLength = string.length() * Math.min(componentWidth, baseNameWidth) / baseNameWidth;
         return shorten(string, maxPathLength);
     }
 
     /**
      * Transforms bits into a meaningful string using the formatting character.
+     * <p>
+     * Note: {@link Bits} carries at most 32 bits of numeric data. When formatting a 64-bit float
+     * ({@code format == 'f'} and {@code bits.length == 64}), only the low 32 bits are available, so the
+     * high 4 bytes of the {@code double} are zero and the result cannot represent a full IEEE-754 double.
      *
      * @param format the formatting character ('s' for a string, etc.)
      * @param bits   the bits to format
@@ -87,7 +95,7 @@ public class StringUtils {
             case 'x':
                 return Integer.toHexString(bits.number);
             case 'X':
-                return Integer.toHexString(bits.number).toUpperCase();
+                return Integer.toHexString(bits.number).toUpperCase(Locale.ROOT);
             case '%':
                 return "%";
             default:

--- a/src/main/java/net/emustudio/emulib/runtime/io/IntelHEX.java
+++ b/src/main/java/net/emustudio/emulib/runtime/io/IntelHEX.java
@@ -23,8 +23,8 @@ import java.util.function.Function;
 @NotThreadSafe
 public class IntelHEX {
 
-    // 16-bit Intel HEX has max 15 bytes per line
-    private final static int MAX_DATA_BYTES_COUNT_IN_LINE = 15;
+    // Number of data bytes emitted per data record (standard I8HEX record length)
+    private final static int MAX_DATA_BYTES_COUNT_IN_LINE = 16;
 
     private final Map<Integer, Byte> program = new HashMap<>();
     private int nextAddress;
@@ -50,7 +50,7 @@ public class IntelHEX {
         }
         for (int i = 0; i < hexData.length() - 1; i += 2) {
             String tmp = hexData.substring(i, i + 2);
-            program.put(nextAddress++, Byte.parseByte(tmp, 16));
+            program.put(nextAddress++, (byte) Integer.parseInt(tmp, 16));
         }
         return nextAddress;
     }
@@ -221,7 +221,7 @@ public class IntelHEX {
                 byte[] hex = new byte[2];
                 for (int y = 0; y < bytesCount; y++) {
                     buffer.get(hex);
-                    hexFile.add(Byte.parseByte(new String(hex), 16));
+                    hexFile.add((byte) Integer.parseInt(new String(hex), 16));
                 }
                 // checksum - don't care..
                 ignoreLine(buffer);
@@ -263,7 +263,7 @@ public class IntelHEX {
             }
 
             // if element's address does not equal suggested (naturally computed) address or line is full
-            if ((hexLineAddress.get() != address) || (hexDataBytesCount.get() > MAX_DATA_BYTES_COUNT_IN_LINE)) {
+            if ((hexLineAddress.get() != address) || (hexDataBytesCount.get() >= MAX_DATA_BYTES_COUNT_IN_LINE)) {
                 String fullLine = String.format("%02X%s00%s", hexDataBytesCount.get(), hexLineAddressStr.get(), hexDataBytes);
                 intelHexContent.append(String.format(":%s%s\n", fullLine, checksum(fullLine)));
                 hexDataBytesCount.set(0);
@@ -292,13 +292,8 @@ public class IntelHEX {
             sum += Integer.parseInt(lin.substring(i, i + 2), 16);
         }
         sum %= 0x100;
-        // :
-        // 10 00 08 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-        // 16 0  8  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
-        // 16+8 = 24
-        // 0x100 -24 +1 = 256 - 24 +1 = 232 +1 = 0xe8 + 1 = 0xe9
-        // 0xe9 je zevraj zle, ma byt 0xe8
-        chsum = 0x100 - sum; //+1;
+        // two's complement of the least significant byte of the sum
+        chsum = (0x100 - sum) & 0xFF;
         return String.format("%1$02X", chsum);
     }
 

--- a/src/main/java/net/emustudio/emulib/runtime/ui/ShortenedString.java
+++ b/src/main/java/net/emustudio/emulib/runtime/ui/ShortenedString.java
@@ -44,6 +44,10 @@ public class ShortenedString<T> {
         String fullString = getFullString();
         int fullStringWidth = fontMetrics.stringWidth(fullString);
 
+        if (fullStringWidth <= 0) {
+            this.maxStringLength = fullString.length();
+            return;
+        }
         this.maxStringLength = fullString.length() * Math.min(componentWidth, fullStringWidth) / fullStringWidth;
     }
 

--- a/src/test/java/net/emustudio/emulib/plugins/compiler/FileExtensionTest.java
+++ b/src/test/java/net/emustudio/emulib/plugins/compiler/FileExtensionTest.java
@@ -46,4 +46,16 @@ public class FileExtensionTest {
         String result = stripKnownExtension("file.inc", knownExtensions);
         assertEquals("file", result);
     }
+
+    @Test
+    public void testStripKnownExtensionOnlyStripsTrailingExtension() {
+        // ".asm" appears in the middle but the real extension is ".txt" (unknown) - must be preserved
+        assertEquals("archive.asm.txt", stripKnownExtension("archive.asm.txt", knownExtensions));
+    }
+
+    @Test
+    public void testStripKnownExtensionDoesNotStripPartialMatch() {
+        // "asmtext" is not the "asm" extension
+        assertEquals("file.asmtext", stripKnownExtension("file.asmtext", knownExtensions));
+    }
 }

--- a/src/test/java/net/emustudio/emulib/runtime/helpers/RadixUtilsTest.java
+++ b/src/test/java/net/emustudio/emulib/runtime/helpers/RadixUtilsTest.java
@@ -231,6 +231,17 @@ public class RadixUtilsTest {
     }
 
     @Test
+    public void testParseOctalWithSuffix() {
+        assertEquals(15, RadixUtils.getInstance().parseRadix("17o"));
+        assertEquals(15, RadixUtils.getInstance().parseRadix("17o", 8));
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void testParseInvalidOctalSuffixThrows() {
+        RadixUtils.getInstance().parseRadix("89o");
+    }
+
+    @Test
     public void testFormatBinaryStringWithoutSpaces() {
         assertEquals("00100000", RadixUtils.formatBinaryString(32, 8));
         assertEquals("00000000", RadixUtils.formatBinaryString(0, 8));

--- a/src/test/java/net/emustudio/emulib/runtime/helpers/StringUtilsTest.java
+++ b/src/test/java/net/emustudio/emulib/runtime/helpers/StringUtilsTest.java
@@ -122,10 +122,11 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void testFormatLargeHexValue() {
-        Bits bits = new Bits(0xABCDEF, 32);
-        assertEquals("abcdef", StringUtils.format('x', bits));
-        assertEquals("ABCDEF", StringUtils.format('X', bits));
+    public void testShortenWithComponentEmptyStringDoesNotThrow() {
+        // An empty string has zero rendered width; the component overload must not divide by zero.
+        javax.swing.JLabel label = new javax.swing.JLabel();
+        label.setFont(new java.awt.Font(java.awt.Font.MONOSPACED, java.awt.Font.PLAIN, 12));
+        assertEquals("", StringUtils.shorten("", label, 100));
     }
 
 }

--- a/src/test/java/net/emustudio/emulib/runtime/io/IntelHEXTest.java
+++ b/src/test/java/net/emustudio/emulib/runtime/io/IntelHEXTest.java
@@ -108,6 +108,42 @@ public class IntelHEXTest {
     }
 
     @Test
+    public void testHighBytesAreParsedFromHexString() {
+        hexFile.add("80FF00C0");
+        Map<Integer, Byte> codeTable = hexFile.getCode();
+        assertEquals((byte) 0x80, (byte) codeTable.get(0));
+        assertEquals((byte) 0xFF, (byte) codeTable.get(1));
+        assertEquals((byte) 0x00, (byte) codeTable.get(2));
+        assertEquals((byte) 0xC0, (byte) codeTable.get(3));
+    }
+
+    @Test
+    public void testHighBytesRoundTripThroughGenerateAndParse() throws Exception {
+        hexFile.add(new byte[]{(byte) 0x80, (byte) 0xFF, (byte) 0xAB, (byte) 0xCD});
+        Path tmpName = Path.of("tmp" + System.currentTimeMillis());
+        hexFile.generate(tmpName);
+        try {
+            IntelHEX parsed = IntelHEX.parse(tmpName.toFile());
+            Map<Integer, Byte> codeTable = parsed.getCode();
+            assertEquals((byte) 0x80, (byte) codeTable.get(0));
+            assertEquals((byte) 0xFF, (byte) codeTable.get(1));
+            assertEquals((byte) 0xAB, (byte) codeTable.get(2));
+            assertEquals((byte) 0xCD, (byte) codeTable.get(3));
+        } finally {
+            tmpName.toFile().delete();
+        }
+    }
+
+    @Test
+    public void testChecksumIsAlwaysTwoHexDigits() throws Exception {
+        // A single 0xFF byte at address 0 makes the byte-sum a multiple of 0x100,
+        // which previously produced a malformed 3-character checksum ("100").
+        hexFile.add((byte) 0xFF);
+        List<String> content = generateReadAndDeleteHexFile();
+        content.forEach(this::assertHexLineIsValid);
+    }
+
+    @Test
     public void testPutEmptyCode() throws Exception {
         hexFile.add("");
         List<String> content = generateReadAndDeleteHexFile();


### PR DESCRIPTION
## Overview

This PR (branch `feature-76`) bundles two independent pieces of work:

- **#111** — Bug fixes and consistency cleanups across the helpers/IO utilities, with tests.
- **#112** — New C4 architecture documentation and a Gradle task to render it.

Closes #111
Closes #112

## #111 — Fix bugs and inconsistencies in helpers/IO

### Bug fixes
- **IntelHEX**: parse high data bytes (`>= 0x80`) via `Integer.parseInt` instead of `Byte.parseByte`, which threw `NumberFormatException` on values like `FF`.
- **IntelHEX**: mask the checksum to a single byte so `String.format("%02X")` never emits 3 hex digits when the byte sum is a multiple of 256.
- **FileExtension.stripKnownExtension**: only strip a genuine trailing extension, so `archive.asm.txt` is no longer truncated to `archive`.
- **StringUtils.shorten(String, Component, int)**: guard zero-width strings.
- **ShortenedString**: guard zero `fullStringWidth` to avoid division by zero.
- **RadixUtils**: remove the dead leading-zero octal pattern and tighten the octal suffix pattern to `[0-7]+o` so invalid digits (`8`, `9`) are rejected consistently.

### Cleanups / consistency
- **IntelHEX**: rename `MAX_DATA_BYTES_COUNT_IN_LINE` to the honest value `16` and use `>=`; output is byte-for-byte identical.
- **StringUtils.format('X')**: use `Locale.ROOT` for upper-casing.
- **SleepUtils**: replace `System.out.println` in static init with slf4j debug logs.
- **NumberUtils**: remove the unused private `reverseByte(int)`.
- **SourceCodePosition**: add the missing `getFileName()` accessor.

### Documentation
- `NumberUtils.reverseBits(long, int)`: document the intentional difference from the `int` overload (low bits only; higher bits cleared; `<= 0` yields `0`).
- `StringUtils.format()`: document that 64-bit float formatting only uses the low 32 bits because `Bits` holds 32 bits.

Tests added for the above behaviour changes.

## #112 — C4 architecture documentation + Gradle `doc` task

- **`docs/architecture.adoc`** — full C4-model documentation (Context, Container, Component, Code) with C4-PlantUML diagrams, plus cross-cutting concerns (concurrency, headless/automation, extensibility, distribution/versioning).
- **`build.gradle`** — new `doc` task (group `documentation`) using `org.asciidoctor.jvm.convert` + `asciidoctor-diagram`; renders `docs/*.adoc` to HTML into `docs/output/`.
- **`.gitignore`** — ignore the generated `docs/output/`.

Render the docs locally with:

```bash
./gradlew doc
```

## Notes

- Also adds `AGENTS.md` (repository-routing and commit-convention notes for tooling).

## Verification

- `./gradlew test` — helpers/IO changes are covered by the added tests.
- `./gradlew doc` — produces `docs/output/architecture.html` and 6 rendered SVG diagrams (verified: no PlantUML error placeholders; task is incremental).
